### PR TITLE
Add ability to bind arbitrary methods to javascript functions

### DIFF
--- a/src/ofxAwesomiumPlus.cpp
+++ b/src/ofxAwesomiumPlus.cpp
@@ -308,6 +308,25 @@ void ofxAwesomiumPlus::Bind(Awesomium::JSObject& object,
     bound_methods_[key] = callback;
 }
 
+void ofxAwesomiumPlus::bind(const string& name,
+                            JSDelegate callback) {
+    WebString _name = WSLit(name.c_str());
+    JSValue result = web_view->CreateGlobalJavascriptObject(WSLit(_appName.c_str()));
+    if (result.IsObject()) {
+        // Bind our custom method to it.
+        JSObject& object = result.ToObject();
+        
+        // We can't bind methods to local JSObjects
+        if (object.type() == Awesomium::kJSObjectType_Local)
+            return;
+        
+        object.SetCustomMethod(_name, false);
+        
+        ObjectMethodKey key(object.remote_id(), _name);
+        bound_methods_[key] = callback;
+    }
+}
+
 void ofxAwesomiumPlus::BindWithRetval(Awesomium::JSObject& object,
                                  const Awesomium::WebString& name,
                                  JSDelegateWithRetval callback) {

--- a/src/ofxAwesomiumPlus.h
+++ b/src/ofxAwesomiumPlus.h
@@ -88,6 +88,9 @@ public:
               const Awesomium::WebString& name,
               JSDelegate callback);
     
+    void bind(const string& name,
+              JSDelegate callback);
+    
     void BindWithRetval(Awesomium::JSObject& object,
                         const Awesomium::WebString& name,
                         JSDelegateWithRetval callback);


### PR DESCRIPTION
Implemented in a similar way as in issue #2 suggested.

Assue you want to listen to the javascript function `buttonPressed`. You can now listen to it like so:

``` c++
// Listen to button presses
browser.bind("buttonPressed", JSDelegate(this, &ofApp::onWebButtonPressed));

---

void ofApp::onWebButtonPressed(WebView* caller, const JSArray& args) {
}
```

You can probably get rid of the `JSDelegate` in the function call by passing `this` and the function pointer and assemble them later with `JSDelegate`. But it seems there are many ways to call a function with a function pointer [see ofEventUtils.h](https://github.com/openframeworks/openFrameworks/blob/master/libs/openFrameworks/events/ofEventUtils.h). But still I think this important to have and a good starting point.
